### PR TITLE
Fix for the fully connected layer.

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -43,8 +43,7 @@ class Generator:
             # need to get the first index of each sentence to enforce rhyme
             self.inputs = tf.placeholder(tf.int32, shape=[self.batch_size,
                                                           self.sequence_length])
-            self.processed_inputs = tf.transpose(tf.nn.embedding_lookup(self.g_embeddings,
-                                                                        self.inputs), perm=[1, 0, 2])
+            self.processed_inputs = tf.nn.embedding_lookup(self.g_embeddings, self.inputs)
         with tf.device("/cpu:0"):
             self.processed_x = tf.transpose(tf.nn.embedding_lookup(self.g_embeddings, self.x),
                                             perm=[1, 0, 2])  # seq_length x batch_size x emb_dim for LSTM


### PR DESCRIPTION
It seems a bug.

```python
a = np.arange(12)
a.reshape((2, 6))
b = a.transpose()
>>> a
array([[ 0,  1,  2,  3,  4,  5],
       [ 6,  7,  8,  9, 10, 11]])
>>> b
array([[ 0,  6],
       [ 1,  7],
       [ 2,  8],
       [ 3,  9],
       [ 4, 10],
       [ 5, 11]])
>>> a.reshape((3, -1))
array([[ 0,  1,  2,  3],
       [ 4,  5,  6,  7],
       [ 8,  9, 10, 11]])
>>> b.reshape((3, -1))
array([[ 0,  6,  1,  7],
       [ 2,  8,  3,  9],
       [ 4, 10,  5, 11]])
>>> a.reshape((3, -1)) == b.reshape((3, -1))
array([[ True, False, False, False],
       [False, False, False, False],
       [False, False, False,  True]])
```